### PR TITLE
Always set brightness level under the maximum allowed by device

### DIFF
--- a/src/Hbacklight.hs
+++ b/src/Hbacklight.hs
@@ -190,10 +190,10 @@ dim (dpath, dsub) i op minV = do
                 >> return (i { brightness = v } )
             setV = writeV . toMin
             runOp = \case
-                Op Plus x    -> setV $ lvl + x
+                Op Plus x    -> setV $ min (lvl + x) (maxB i)
                 Op Minus x   -> setV $ lvl - x
                 Op Percent x -> setV $ x * maxB i `div` 100
-                Op Set x     -> setV x
+                Op Set x     -> setV $ min x (maxB i)
 
  -- list all available led and backlight devices
 enumDevices :: TFilePath -> TFilePath -> IO Box


### PR DESCRIPTION
On my system, setting the brightness level above the `max_brigthness` results in an error:
```
$ cat /sys/class/backlight/nv_backlight1/max_brightness
100
$ echo 101 > /sys/class/backlight/nv_backlight1/brightness
bash: echo: write error: Invalid argument
```

`hbacklight` suffers from the same error:

```
$ hbacklight -i nv_backlight1 -d +101
hbacklight: fdWriteBuf: invalid argument (Invalid argument)
$ hbacklight -i nv_backlight1 -d 101
hbacklight: fdWriteBuf: invalid argument (Invalid argument)
```

This PR makes `hbacklight` handle gracefully such cases by never allowing to set a brightness level above the maximum allowed.